### PR TITLE
Fix PWA installation paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,8 @@
     <link rel="stylesheet" href="css/modern-ui.css">
     <link rel="stylesheet" href="css/custom.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/js/all.min.js" crossorigin="anonymous"></script>
-    <link rel="manifest" href="/GuidedAmbitions/manifest.json">
+    <link rel="manifest" href="manifest.json">
+    <meta name="theme-color" content="#004080">
 </head>
 <body>
     <!-- Page Loader -->
@@ -416,7 +417,7 @@
   <script>
   if ("serviceWorker" in navigator) {
     navigator.serviceWorker
-      .register("/GuidedAmbitions/sw.js")
+      .register("sw.js")
       .then(reg => console.log("SW registered:", reg))
       .catch(err => console.error("SW registration failed:", err));
   }

--- a/job-identifier.html
+++ b/job-identifier.html
@@ -5,7 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Guided Ambitions - Veteran Transition Platform</title>
   <link rel="stylesheet" href="css/jobstyle.css">
-  <link rel="manifest" href="/GuidedAmbitions/manifest.json">
+  <link rel="manifest" href="manifest.json">
+  <meta name="theme-color" content="#004080">
 </head>
 <body>
   <header>
@@ -206,7 +207,7 @@
  <script>
   if ("serviceWorker" in navigator) {
     navigator.serviceWorker
-      .register("/GuidedAmbitions/sw.js")
+      .register("sw.js")
       .then(reg => console.log("SW registered:", reg))
       .catch(err => console.error("SW registration failed:", err));
   }

--- a/login.html
+++ b/login.html
@@ -8,7 +8,8 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Montserrat:wght@600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/modern-ui.css">
     <link rel="stylesheet" href="css/custom.css">
-    <link rel="manifest" href="/GuidedAmbitions/manifest.json">
+    <link rel="manifest" href="manifest.json">
+    <meta name="theme-color" content="#004080">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/js/all.min.js" crossorigin="anonymous"></script>
 </head>
  <body>
@@ -426,7 +427,7 @@
     <script>
   if ("serviceWorker" in navigator) {
     navigator.serviceWorker
-      .register("/GuidedAmbitions/sw.js")
+      .register("sw.js")
       .then(reg => console.log("SW registered:", reg))
       .catch(err => console.error("SW registration failed:", err));
   }

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "name": "Guided Ambitions Platform",
   "short_name": "GuidedAmbitions",
-  "start_url": "/GuidedAmbitions/login.html",
-  "scope": "/GuidedAmbitions/",
+  "start_url": "login.html",
+  "scope": "./",
   "display": "standalone",
   "background_color": "#ffffff",
   "theme_color": "#004080",
@@ -10,12 +10,12 @@
   "orientation": "portrait",
   "icons": [
     {
-      "src": "/GuidedAmbitions/images/icon-192.png",
+      "src": "images/icon-192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "/GuidedAmbitions/images/icon-512.png",
+      "src": "images/icon-512.png",
       "sizes": "512x512",
       "type": "image/png"
     }

--- a/sw.js
+++ b/sw.js
@@ -2,19 +2,19 @@
 
 const CACHE_NAME = "guided-ambitions-cache-v1";
 const urlsToCache = [
-  "/GuidedAmbitions/index.html",
-  "/GuidedAmbitions/login.html",
-  "/GuidedAmbitions/job-identifier.html",
-  "/GuidedAmbitions/css/modern-ui.css",
-  "/GuidedAmbitions/css/custom.css",
-  "/GuidedAmbitions/css/jobstyle.css",
-  "/GuidedAmbitions/manifest.json",
-  "/GuidedAmbitions/images/icon-192.png",
-  "/GuidedAmbitions/images/icon-512.png",
-  "/GuidedAmbitions/components/skill_translator/index.html",
-  "/GuidedAmbitions/components/resume_generator/index.html",
-  "/GuidedAmbitions/components/ats_scanner/index.html",
-  "/GuidedAmbitions/components/interview_coach/index.html"
+  "index.html",
+  "login.html",
+  "job-identifier.html",
+  "css/modern-ui.css",
+  "css/custom.css",
+  "css/jobstyle.css",
+  "manifest.json",
+  "images/icon-192.png",
+  "images/icon-512.png",
+  "components/skill_translator/index.html",
+  "components/resume_generator/index.html",
+  "components/ats_scanner/index.html",
+  "components/interview_coach/index.html"
 ];
 
 self.addEventListener("install", (event) => {


### PR DESCRIPTION
## Summary
- use relative paths in `manifest.json` to ensure scope and start URL work regardless of hosting path
- cache files with relative URLs in `sw.js`
- update HTML files with relative manifest link, theme color, and service worker registration

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6856ad954ae4832eaa695164f96dd8d2